### PR TITLE
Revert "update dependency jszip to v3"

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "file-saver": "2.0.2",
     "firebase": "6.2.2",
     "font-awesome": "4.7.0",
-    "jszip": "3.2.1",
+    "jszip": "2.6.1",
     "jszip-utils": "0.0.2",
     "materialize-css": "1.0.0",
     "moment": "2.24.0",


### PR DESCRIPTION
The dependency "docxtemplater" requires JSZip v2.