### PR TITLE
feat: redirect from / straight to current year list page

### DIFF
--- a/src/app/no-user.guard.ts
+++ b/src/app/no-user.guard.ts
@@ -25,7 +25,7 @@ export class NoUserGuard implements CanActivate, CanLoad {
         if (!authState) {
           return true;
         } else {
-          this.router.navigate(['/', 'main']);
+          this.router.navigate(['/', 'main', new Date().getFullYear(), 'normal']);
           return false;
         }
       })


### PR DESCRIPTION
As "special" mode is no longer used, authenticated user should be redirected straight to current year document list (e.g. /main/2021/normal), saving time & database read.